### PR TITLE
Refactor request and response RPCs for Accounts and Safecoin

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -296,7 +296,6 @@ pub enum Request {
     //
     /// Balance transfer
     TransferCoins {
-        source: XorName,
         destination: XorName,
         amount: Coins,
         transaction_id: u64, // TODO: Use the trait UUID
@@ -307,11 +306,9 @@ pub enum Request {
         transaction_id: u64, // TODO: Use the trait UUID
     },
     /// Get current wallet balance
-    GetBalance(XorName),
+    GetBalance,
     /// Create a new coin balance
     CreateCoinBalance {
-        source: XorName,
-        destination: XorName,
         new_balance_owner: PublicKey,
         amount: Coins,
         transaction_id: u64, // TODO: Use the trait UUID
@@ -394,7 +391,7 @@ impl fmt::Debug for Request {
                 AppendUnseq(_) => "Request::AppendUnseq",
                 TransferCoins { .. } => "Request::TransferCoins",
                 GetTransaction { .. } => "Request::GetTransaction",
-                GetBalance(_) => "Request::GetBalance",
+                GetBalance => "Request::GetBalance",
                 ListAuthKeysAndVersion => "Request::ListAuthKeysAndVersion",
                 InsAuthKey { .. } => "Request::InsAuthKey",
                 DelAuthKey { .. } => "Request::DelAuthKey",

--- a/src/response.rs
+++ b/src/response.rs
@@ -98,6 +98,13 @@ pub enum Response {
     InsAuthKey(Result<()>),
     /// Returns a success or failure status of deleting an authorised key.
     DelAuthKey(Result<()>),
+    //
+    // ===== Account =====
+    //
+    /// Returns a success or failure status of putting a new account.
+    PutAccount(Result<()>),
+    /// Returns an encrypted account packet
+    GetAccount(Result<Vec<u8>>),
 }
 
 use std::fmt;
@@ -159,6 +166,8 @@ impl fmt::Debug for Response {
                 GetADataShell(..) => "Response::GetADataShell",
                 GetADataOwners(..) => "Response::GetADataOwners",
                 SetADataOwner(..) => "Response::SetADataOwner",
+                PutAccount(..) => "Response::PutAccount",
+                GetAccount(..) => "Response::GetAccount",
             }
         )
     }


### PR DESCRIPTION
- remove source and destination fields from safecoin RPCs, they should
be derived from the Public ID of the requester
- add response variants for get and put account